### PR TITLE
Fixed typo calender => calendar

### DIFF
--- a/src/Aggregation/Bucketing/DateHistogramAggregation.php
+++ b/src/Aggregation/Bucketing/DateHistogramAggregation.php
@@ -102,7 +102,7 @@ class DateHistogramAggregation extends AbstractAggregation
     public function getArray()
     {
         if ($this->getCalendarInterval() === null && $this->getFixedInterval() === null) {
-            throw new \LogicException('Date histogram aggregation must have field and calender_interval or fixed_interval set.');
+            throw new \LogicException('Date histogram aggregation must have field and calendar_interval or fixed_interval set.');
         }
 
         $out = [
@@ -110,7 +110,7 @@ class DateHistogramAggregation extends AbstractAggregation
         ];
 
         if ($this->getCalendarInterval()) {
-            $out['calender_interval'] = $this->getCalendarInterval();
+            $out['calendar_interval'] = $this->getCalendarInterval();
         }
 
         if ($this->getFixedInterval()) {

--- a/tests/Unit/Aggregation/Bucketing/DateHistogramAggregationTest.php
+++ b/tests/Unit/Aggregation/Bucketing/DateHistogramAggregationTest.php
@@ -40,7 +40,7 @@ class DateHistogramAggregationTest extends \PHPUnit\Framework\TestCase
         $aggregation->setField('date');
         $aggregation->setCalendarInterval('month');
         $result = $aggregation->getArray();
-        $expected = ['field' => 'date', 'calender_interval' => 'month'];
+        $expected = ['field' => 'date', 'calendar_interval' => 'month'];
         static::assertEquals($expected, $result);
     }
 
@@ -61,7 +61,7 @@ class DateHistogramAggregationTest extends \PHPUnit\Framework\TestCase
         static::assertSame([
             'date_histogram' => [
                 'field' => 'test',
-                'calender_interval' => '1m',
+                'calendar_interval' => '1m',
                 'fixed_interval' => '1m',
                 'time_zone' => 'Europe/Berlin',
                 'format' => 'YYYY-mm-dd',


### PR DESCRIPTION
The aggregation currently contains a typo that causes a bad request in Opensearch.

 unknown field [calender_interval] did you mean any of [calendar_interval, fixed_interval]