### PR TITLE
Ignore empty array normalized values

### DIFF
--- a/src/Serializer/OrderedSerializer.php
+++ b/src/Serializer/OrderedSerializer.php
@@ -24,11 +24,13 @@ class OrderedSerializer
                 if ($value instanceof AbstractSearchEndpoint) {
                     $normalize = $value->normalize();
 
-                    if ($normalize !== null) {
-                        $data[$key] = $normalize;
-                    } else {
+                    if ($normalize === null || count($normalize) === 0) {
                         unset($data[$key]);
+
+                        continue;
                     }
+
+                    $data[$key] = $normalize;
                 }
             }
         }

--- a/tests/Unit/Serializer/OrderedSerializerTest.php
+++ b/tests/Unit/Serializer/OrderedSerializerTest.php
@@ -5,6 +5,7 @@ namespace OpenSearchDSL\Tests\Unit\Serializer;
 use OpenSearchDSL\Query\MatchAllQuery;
 use OpenSearchDSL\Query\TermLevel\TermsQuery;
 use OpenSearchDSL\Search;
+use OpenSearchDSL\SearchEndpoint\AggregationsEndpoint;
 use OpenSearchDSL\SearchEndpoint\HighlightEndpoint;
 use OpenSearchDSL\SearchEndpoint\PostFilterEndpoint;
 use OpenSearchDSL\SearchEndpoint\QueryEndpoint;
@@ -44,7 +45,7 @@ class OrderedSerializerTest extends TestCase
         );
     }
 
-    public function testNullFieldGetsDropped(): void
+    public function testNullOrEmptyArrayFieldGetsDropped(): void
     {
         $serializer = new OrderedSerializer();
 
@@ -55,6 +56,7 @@ class OrderedSerializerTest extends TestCase
             $serializer->normalize(
                 [
                     $search->getEndpoint(HighlightEndpoint::NAME),
+                    $search->getEndpoint(AggregationsEndpoint::NAME),
                 ]
             )
         );


### PR DESCRIPTION
Empty array normalized values should be ommited, otherwise it end up included to query