### PR TITLE
Allow overriding keys in various search endpoints

### DIFF
--- a/src/Search.php
+++ b/src/Search.php
@@ -249,9 +249,9 @@ class Search
      *
      * @return $this
      */
-    public function addAggregation(AbstractAggregation $aggregation)
+    public function addAggregation(AbstractAggregation $aggregation, ?string $key = null)
     {
-        $this->getEndpoint(AggregationsEndpoint::NAME)->add($aggregation, $aggregation->getName());
+        $this->getEndpoint(AggregationsEndpoint::NAME)->add($aggregation, $key ?: $aggregation->getName());
 
         return $this;
     }

--- a/src/Search.php
+++ b/src/Search.php
@@ -271,9 +271,9 @@ class Search
      *
      * @return $this
      */
-    public function addInnerHit(NestedInnerHit $innerHit)
+    public function addInnerHit(NestedInnerHit $innerHit, ?string $key = null)
     {
-        $this->getEndpoint(InnerHitsEndpoint::NAME)->add($innerHit, $innerHit->getName());
+        $this->getEndpoint(InnerHitsEndpoint::NAME)->add($innerHit, $key ?: $innerHit->getName());
 
         return $this;
     }
@@ -293,9 +293,9 @@ class Search
      *
      * @return $this
      */
-    public function addSort(BuilderInterface $sort)
+    public function addSort(BuilderInterface $sort, ?string $key = null)
     {
-        $this->getEndpoint(SortEndpoint::NAME)->add($sort);
+        $this->getEndpoint(SortEndpoint::NAME)->add($sort, $key);
 
         return $this;
     }
@@ -342,9 +342,9 @@ class Search
      *
      * @return $this
      */
-    public function addSuggest(NamedBuilderInterface $suggest)
+    public function addSuggest(NamedBuilderInterface $suggest, ?string $key = null)
     {
-        $this->getEndpoint(SuggestEndpoint::NAME)->add($suggest, $suggest->getName());
+        $this->getEndpoint(SuggestEndpoint::NAME)->add($suggest, $key ?: $suggest->getName());
 
         return $this;
     }

--- a/tests/Unit/SearchTest.php
+++ b/tests/Unit/SearchTest.php
@@ -129,6 +129,30 @@ class SearchTest extends \PHPUnit\Framework\TestCase
         static::assertSame('bar', $search->getUriParams()['q']);
     }
 
+    public function testSortsCanHaveKey(): void
+    {
+        $search = new Search();
+
+        static::assertSame($search, $search->addSort(new FieldSort('foo'), 'sort-key'));
+        static::assertArrayHasKey('sort-key', $search->getSorts());
+    }
+
+    public function testInnerHitCanHaveKey(): void
+    {
+        $search = new Search();
+
+        static::assertSame($search, $search->addInnerHit(new NestedInnerHit('foo', 'foo'), 'inner-hit-key'));
+        static::assertArrayHasKey('inner-hit-key', $search->getInnerHits());
+    }
+
+    public function testSuggestCanHaveKey(): void
+    {
+        $search = new Search();
+
+        static::assertSame($search, $search->addSuggest(new Suggest('foo', 'suggest', 'foo_bar', 'bar'), 'suggest-key'));
+        static::assertArrayHasKey('suggest-key', $search->getSuggests());
+    }
+
     public function testGetters(): void
     {
         $search = new Search();

--- a/tests/Unit/SearchTest.php
+++ b/tests/Unit/SearchTest.php
@@ -129,6 +129,14 @@ class SearchTest extends \PHPUnit\Framework\TestCase
         static::assertSame('bar', $search->getUriParams()['q']);
     }
 
+    public function testAggregationCanHaveKey(): void
+    {
+        $search = new Search();
+
+        static::assertSame($search, $search->addAggregation(new TermsAggregation('acme'), 'aggregation-key'));
+        static::assertArrayHasKey('aggregation-key', $search->getAggregations());
+    }
+
     public function testSortsCanHaveKey(): void
     {
         $search = new Search();


### PR DESCRIPTION
This PR:

- [x] Allows overriding the key by which the `Aggregation`, `InnerHit`, `Sort`, and `Suggest` builders are added to the search query.
- [x] Adds tests for the functionality.

I tried adding this same functionality to `Suggest` and `Highlight` builders (the `Search::addSuggest` and `Search::addHighlight` methods), but those are a bit more complex. If that's wanted I can work on it but would rather do so in a separate PR.

---

Reasoning behind this: I was looking for a way to remove a specific `Sort` builder on the search query to enforce only limited sort options, but the keys are randomly generated at the moment. I could loop through and filter over them, but figured it could be simpler. Turns out the `\OpenSearchDSL\SearchEndpoint\AbstractSearchEndpoint::add` supports passing a `$key`, but that is not exposed through the `Search` class right now. 