### PR TITLE
ScriptQuery: use source instead of inline

### DIFF
--- a/src/Query/Specialized/ScriptQuery.php
+++ b/src/Query/Specialized/ScriptQuery.php
@@ -33,7 +33,7 @@ class ScriptQuery implements BuilderInterface
 
     public function toArray(): array
     {
-        $query = ['inline' => $this->script];
+        $query = ['source' => $this->script];
         $output = $this->processArray($query);
 
         return [$this->getType() => ['script' => $output]];

--- a/tests/Unit/Query/Specialized/ScriptQueryTest.php
+++ b/tests/Unit/Query/Specialized/ScriptQueryTest.php
@@ -45,12 +45,12 @@ class ScriptQueryTest extends \PHPUnit\Framework\TestCase
             'simple_script' => [
                 "doc['num1'].value > 1",
                 [],
-                ['script' => ['inline' => "doc['num1'].value > 1"]],
+                ['script' => ['source' => "doc['num1'].value > 1"]],
             ],
             'script_with_parameters' => [
                 "doc['num1'].value > param1",
                 ['params' => ['param1' => 5]],
-                ['script' => ['inline' => "doc['num1'].value > param1", 'params' => ['param1' => 5]]],
+                ['script' => ['source' => "doc['num1'].value > param1", 'params' => ['param1' => 5]]],
             ],
         ];
     }


### PR DESCRIPTION
I was investigating application logs and we have tons of these deprecation warnings
(SW 6.6, ES 7.9)

```
[2026-03-11T15:23:18.061613+00:00] elasticsearch.WARNING: Deprecation ["299 Elasticsearch-7.9.3-c3ae218b3ba0c8a91055c37c48df5d05bc3fdea9 \"[script][1:617] Deprecated field [inline] used, expected [source] instead\"","299 Elasticsearch-7.9.3-c3ae218b3ba0c8a91055c37c48df5d05bc3fdea9 \"[script][1:4506] Deprecated field [inline] used, expected [source] instead\"","299 Elasticsearch-7.9.3-c3ae218b3ba0c8a91055c37c48df5d05bc3fdea9 \"[script][1:6758] Deprecated field [inline] used, expected [source] instead\"","299 Elasticsearch-7.9.3-c3ae218b3ba0c8a91055c37c48df5d05bc3fdea9 \"[script][1:9088] Deprecated field [inline] used, expected [source] instead\"","299 Elasticsearch-7.9.3-c3ae218b3ba0c8a91055c37c48df5d05bc3fdea9 \"[script][1:11231] Deprecated field [inline] used, expected [source] instead\"","299 Elasticsearch-7.9.3-c3ae218b3ba0c8a91055c37c48df5d05bc3fdea9 \"[script][1:13396] Deprecated field [inline] used, expected [source] instead\""] []
```

To prevent this warning, we could move from using `inline` to `source`.

ES 5.5 is the last version referencing `inline` in the docs: https://www.elastic.co/guide/en/elasticsearch/reference/5.5/modules-scripting-using.html#CO304-2
Anything past that uses `source`, e.g: https://www.elastic.co/guide/en/elasticsearch/reference/5.6/modules-scripting-using.html#CO317-2

Disclaimer: My knowledge is limited and I don't know if it affects the OpenSearch side. I roughly crosschecked the latest docs and it looks like they don't use `inline` either: https://docs.opensearch.org/3.4/query-dsl/specialized/script/#basic-script-query:~:text=%7B%0A%20%20%20%20%20%20%22script%22%3A%20%7B%0A%20%20%20%20%20%20%20%20%22-,source,-%22%3A%20%22doc%5B%27rating%27%5D.value%20%3E%204.6