### PR TITLE
Fix php 8.5 deprecation

### DIFF
--- a/src/SearchEndpoint/AbstractSearchEndpoint.php
+++ b/src/SearchEndpoint/AbstractSearchEndpoint.php
@@ -33,12 +33,12 @@ abstract class AbstractSearchEndpoint extends AbstractNormalizable
 
     public function add(BuilderInterface $builder, ?string $key = null): string
     {
-        if (array_key_exists($key ?? '', $this->container)) {
-            throw new \OverflowException(sprintf('Builder with %s name for endpoint has already been added!', $key));
-        }
-
         if (!$key) {
             $key = bin2hex(random_bytes(self::KEY_LENGTH));
+        }
+
+        if (array_key_exists($key, $this->container)) {
+            throw new \OverflowException(sprintf('Builder with %s name for endpoint has already been added!', $key));
         }
 
         $this->container[$key] = $builder;

--- a/src/SearchEndpoint/AbstractSearchEndpoint.php
+++ b/src/SearchEndpoint/AbstractSearchEndpoint.php
@@ -33,7 +33,7 @@ abstract class AbstractSearchEndpoint extends AbstractNormalizable
 
     public function add(BuilderInterface $builder, ?string $key = null): string
     {
-        if (array_key_exists($key, $this->container)) {
+        if (array_key_exists($key ?? '', $this->container)) {
             throw new \OverflowException(sprintf('Builder with %s name for endpoint has already been added!', $key));
         }
 


### PR DESCRIPTION
When adding a search or aggregation without specifying a value for the key parameter, the following php deprecation is emitted in php 8.5:
```
Using null as the key parameter for array_key_exists() is deprecated, use an empty string instead
```
The deprecation is also documented here: https://www.php.net/manual/en/function.array-key-exists.php

It seems like the fact that the array key's existence is checked before generating a new key on null values is an oversight, as that check will never succeed unless someone explicitly passed an empty string as the key.